### PR TITLE
Fix/proxy encoding

### DIFF
--- a/src/vng/testsession/api_views.py
+++ b/src/vng/testsession/api_views.py
@@ -465,7 +465,7 @@ class RunTest(CSRFExemptMixin, View):
 
         self.save_call(request, request_method_name, request.subdomain,
                        self.kwargs['relative_url'], session, response.status_code, session_log)
-        if response.apparent_encoding == 'ascii':
+        if response.encoding or ('Content-Type' in response.headers and response.headers['Content-Type']):
             reply = HttpResponse(self.parse_response(response, request, eu.vng_endpoint.url, endpoints), status=response.status_code)
         else:
             reply = HttpResponse(response, status=response.status_code)

--- a/src/vng/testsession/api_views.py
+++ b/src/vng/testsession/api_views.py
@@ -465,7 +465,7 @@ class RunTest(CSRFExemptMixin, View):
 
         self.save_call(request, request_method_name, request.subdomain,
                        self.kwargs['relative_url'], session, response.status_code, session_log)
-        if response.encoding:
+        if response.apparent_encoding == 'ascii':
             reply = HttpResponse(self.parse_response(response, request, eu.vng_endpoint.url, endpoints), status=response.status_code)
         else:
             reply = HttpResponse(response, status=response.status_code)

--- a/src/vng/testsession/api_views.py
+++ b/src/vng/testsession/api_views.py
@@ -465,10 +465,7 @@ class RunTest(CSRFExemptMixin, View):
 
         self.save_call(request, request_method_name, request.subdomain,
                        self.kwargs['relative_url'], session, response.status_code, session_log)
-        if response.encoding or ('Content-Type' in response.headers and response.headers['Content-Type']):
-            reply = HttpResponse(self.parse_response(response, request, eu.vng_endpoint.url, endpoints), status=response.status_code)
-        else:
-            reply = HttpResponse(response, status=response.status_code)
+        reply = HttpResponse(self.parse_response(response, request, eu.vng_endpoint.url, endpoints), status=response.status_code)
         white_headers = ['Content-type', 'location']
         for h in white_headers:
             if h in response.headers:


### PR DESCRIPTION
I found out that the problem lies in the fact that, if the header is Content-type: application/json,  the module requests detect the encoding if after application/json there is also the format, otherwise it returns none. Then this change should handle that situation